### PR TITLE
fix(deploy): replace pickle socket protocol with safe npz

### DIFF
--- a/deploy/client.py
+++ b/deploy/client.py
@@ -2,7 +2,7 @@
 import math
 import os
 import time
-import pickle
+from io import BytesIO
 import socket
 import struct
 
@@ -38,21 +38,33 @@ class Client:
                     raise ConnectionError(f"Failed to connect to {self.host}:{self.port} after {retry_count} retries: {e}") from e
 
     def _send_with_length_prefix(self, data):
-        serialized = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
+        arrays = {}
+        for key, value in data.items():
+            if isinstance(value, torch.Tensor):
+                value = value.detach().cpu()
+                arrays[key] = value.float().numpy() if value.dtype == torch.bfloat16 else value.numpy()
+            else:
+                arrays[key] = np.asarray(value)
+        buffer = BytesIO()
+        np.savez(buffer, **arrays)
+        serialized = buffer.getvalue()
         self.client_socket.sendall(struct.pack(">I", len(serialized)) + serialized)
 
-    def _recv_with_length_prefix(self):
-        len_data = self.client_socket.recv(4)
-        if not len_data or len(len_data) < 4:
-            raise ConnectionError("Failed to receive response length prefix.")
-        data_len = struct.unpack(">I", len_data)[0]
+    def _recv_all(self, length):
         data = b""
-        while len(data) < data_len:
-            packet = self.client_socket.recv(data_len - len(data))
+        while len(data) < length:
+            packet = self.client_socket.recv(length - len(data))
             if not packet:
                 raise ConnectionError("Connection closed while receiving response.")
             data += packet
-        return pickle.loads(data)
+        return data
+
+    def _recv_with_length_prefix(self):
+        len_data = self._recv_all(4)
+        data_len = struct.unpack(">I", len_data)[0]
+        data = self._recv_all(data_len)
+        with np.load(BytesIO(data), allow_pickle=False) as payload:
+            return torch.from_numpy(payload["actions"].copy())
 
     def __call__(self, **data):
         robot_type = data.get("task_id")

--- a/deploy/client.py
+++ b/deploy/client.py
@@ -14,6 +14,8 @@ from transformers import AutoProcessor
 
 torch.set_printoptions(3, sci_mode=False)
 
+MAX_PAYLOAD_BYTES = 128 * 1024 * 1024
+
 
 class Client:
     def __init__(self, host="localhost", port=10086, model_path=None):
@@ -62,6 +64,8 @@ class Client:
     def _recv_with_length_prefix(self):
         len_data = self._recv_all(4)
         data_len = struct.unpack(">I", len_data)[0]
+        if data_len <= 0 or data_len > MAX_PAYLOAD_BYTES:
+            raise ValueError(f"payload length {data_len} outside allowed range (1..{MAX_PAYLOAD_BYTES})")
         data = self._recv_all(data_len)
         with np.load(BytesIO(data), allow_pickle=False) as payload:
             return torch.from_numpy(payload["actions"].copy())

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -11,6 +11,10 @@ import torch
 from tqdm import tqdm
 from transformers import AutoModel
 
+# Reject absurd length-prefix values before allocating (DoS).
+MAX_PAYLOAD_BYTES = 128 * 1024 * 1024
+MODEL_META_KEYS = frozenset({"task_id", "seed"})
+
 
 class Server:
     def __init__(self, model_path, host, port):
@@ -35,6 +39,8 @@ class Server:
         if not data_len_bytes:
             return None
         data_len = struct.unpack(">I", data_len_bytes)[0]
+        if data_len <= 0 or data_len > MAX_PAYLOAD_BYTES:
+            raise ValueError(f"payload length {data_len} outside allowed range (1..{MAX_PAYLOAD_BYTES})")
         data = self._recv_all(conn, data_len)
         if not data:
             return None
@@ -74,16 +80,19 @@ class Server:
 
                             tic = time.time()
 
-                            data = {
-                                key: (
-                                    value.to(device=self.model.device, dtype=self.model.dtype)
-                                    if isinstance(value, torch.Tensor) and value.is_floating_point()
-                                    else value.to(device=self.model.device)
-                                    if isinstance(value, torch.Tensor)
-                                    else value
-                                )
-                                for key, value in input_data.items()
-                            }
+                            # Keep wire meta out of the model call (clients send task_id/seed).
+                            data = {}
+                            for key, value in input_data.items():
+                                if key in MODEL_META_KEYS:
+                                    continue
+                                if isinstance(value, torch.Tensor):
+                                    if value.is_floating_point():
+                                        data[key] = value.to(device=self.model.device, dtype=self.model.dtype)
+                                    else:
+                                        data[key] = value.to(device=self.model.device)
+                                else:
+                                    # Non-tensor extras are not model inputs on this wire format.
+                                    continue
 
                             outputs = self.model(**data)
                             self._send(conn, outputs.actions)

--- a/deploy/server.py
+++ b/deploy/server.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2026 Xiaomi Corporation.
-import pickle
+from io import BytesIO
 import socket
 import struct
 import time
 import argparse
 import traceback
 
+import numpy as np
 import torch
 from tqdm import tqdm
 from transformers import AutoModel
@@ -29,6 +30,30 @@ class Server:
             data += packet
         return data
 
+    def _recv(self, conn):
+        data_len_bytes = self._recv_all(conn, 4)
+        if not data_len_bytes:
+            return None
+        data_len = struct.unpack(">I", data_len_bytes)[0]
+        data = self._recv_all(conn, data_len)
+        if not data:
+            return None
+        # allow_pickle=False: never deserialize untrusted pickle over the socket.
+        with np.load(BytesIO(data), allow_pickle=False) as payload:
+            return {
+                key: payload[key].item() if payload[key].ndim == 0 else torch.from_numpy(payload[key].copy())
+                for key in payload.files
+            }
+
+    @staticmethod
+    def _send(conn, actions):
+        actions = actions.detach().cpu()
+        array = actions.float().numpy() if actions.dtype == torch.bfloat16 else actions.numpy()
+        buffer = BytesIO()
+        np.savez(buffer, actions=array)
+        data = buffer.getvalue()
+        conn.sendall(struct.pack(">I", len(data)) + data)
+
     def serve(self):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
             server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -43,25 +68,25 @@ class Server:
                     request_count = 0
                     with tqdm(desc="Processing Requests", unit=" req") as pbar:
                         while True:
-                            data_len_bytes = self._recv_all(conn, 4)
-                            if not data_len_bytes:
-                                break
-                            data_len = struct.unpack(">I", data_len_bytes)[0]
-
-                            data = self._recv_all(conn, data_len)
-                            if not data:
+                            input_data = self._recv(conn)
+                            if input_data is None:
                                 break
 
                             tic = time.time()
 
-                            input_data = pickle.loads(data)
-                            robot_type = input_data["task_id"]
-                            data = {key: (value.to(device=self.model.device, dtype=self.model.dtype) if isinstance(value, torch.Tensor) and value.is_floating_point() else value.to(device=self.model.device) if isinstance(value, torch.Tensor) else value) for key, value in input_data.items()}
+                            data = {
+                                key: (
+                                    value.to(device=self.model.device, dtype=self.model.dtype)
+                                    if isinstance(value, torch.Tensor) and value.is_floating_point()
+                                    else value.to(device=self.model.device)
+                                    if isinstance(value, torch.Tensor)
+                                    else value
+                                )
+                                for key, value in input_data.items()
+                            }
 
                             outputs = self.model(**data)
-
-                            response = pickle.dumps(outputs.actions.cpu())
-                            conn.sendall(struct.pack(">I", len(response)) + response)
+                            self._send(conn, outputs.actions)
 
                             toc = time.time()
                             request_count += 1
@@ -91,6 +116,7 @@ def parse_args():
         "--host",
         type=str,
         default="localhost",
+        help="Bind address. Prefer localhost; the wire protocol has no authentication.",
     )
     parser.add_argument(
         "--port",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -65,6 +65,7 @@ tmux attach -t model_servers
 
 - The **server** loads the model with `trust_remote_code=True`, Flash Attention 2, and bfloat16, and serves actions over a length-prefixed socket (`deploy/server.py`).
 - The **client** sends observations via the `AutoProcessor` and decodes returned actions with `processor.decode_action(...)` (`deploy/client.py`).
+- The wire protocol uses NumPy `.npz` archives with `allow_pickle=False` (not `pickle`). Keep the server on a trusted network / loopback — there is still no authentication on the socket.
 
 The server must already be running before a client connects. See the benchmark evaluation guides for end-to-end examples of driving the server with a simulation client:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -66,6 +66,7 @@ tmux attach -t model_servers
 - The **server** loads the model with `trust_remote_code=True`, Flash Attention 2, and bfloat16, and serves actions over a length-prefixed socket (`deploy/server.py`).
 - The **client** sends observations via the `AutoProcessor` and decodes returned actions with `processor.decode_action(...)` (`deploy/client.py`).
 - The wire protocol uses NumPy `.npz` archives with `allow_pickle=False` (not `pickle`). Keep the server on a trusted network / loopback — there is still no authentication on the socket.
+- Payloads are capped at 128 MiB to prevent length-prefix memory exhaustion. `task_id` / `seed` are treated as client meta and are not forwarded into the model call.
 
 The server must already be running before a client connects. See the benchmark evaluation guides for end-to-end examples of driving the server with a simulation client:
 

--- a/xr1/mibot/server/deploy.py
+++ b/xr1/mibot/server/deploy.py
@@ -47,7 +47,7 @@ def load_stats(cfg, device):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Path to the model dir.")
-    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Bind address. Default is loopback; the socket has no authentication.")
     parser.add_argument("--port", type=int, default=10086)
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
`deploy/server.py` previously did `pickle.loads` on every length-prefixed TCP payload. That is unauthenticated remote code execution for any peer that can reach the inference socket (default port `10086`). The in-repo post-training path (`xr1/mibot/server/runtime/`) already avoids this with `np.load(..., allow_pickle=False)`.

This PR:
- Switches `deploy/server.py` + `deploy/client.py` to NumPy `.npz` with `allow_pickle=False` (same pattern as mibot runtime)
- Caps length-prefix payloads at **128 MiB** before allocate
- Stops forwarding wire meta (`task_id`, `seed`) into `model(**kwargs)`
- Changes `xr1/mibot/server/deploy.py` default bind from `0.0.0.0` → `127.0.0.1`
- Documents the safer wire format in `docs/DEPLOYMENT.md`

See also follow-up [#7](https://github.com/XiaomiRobotics/Xiaomi-Robotics-1/pull/7) for mibot `config.yaml` preference + runtime payload caps (if opened).

## Impact
- **Confirmed:** `pickle.loads` on attacker-controlled bytes → arbitrary code execution in the model-server process
- Eval clients that import `deploy.client.Client` keep working after both sides update together
- Wire protocol is a breaking change vs the previous pickle format (repo is days old; no auth / no versioning on the socket)

## Test plan
- [ ] Launch `deploy/server.py` and a RoboCasa / VLABench client against it
- [ ] Confirm a crafted pickle payload is rejected (npz load fails closed)
- [ ] Confirm oversized length prefix is rejected
- [ ] Confirm post-train `mibot/server/deploy.py` still starts on loopback by default