### PR TITLE
fix(mibot): prefer config.yaml and cap socket payload sizes

### DIFF
--- a/xr1/mibot/server/deploy.py
+++ b/xr1/mibot/server/deploy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import os
 from os.path import join as osp
 
 import torch
@@ -17,8 +18,27 @@ def strip_prefix(state_dict, prefix):
     return {key[len(prefix) :]: value for key, value in state_dict.items() if key.startswith(prefix)}
 
 
+def load_config(model_dir):
+    """Prefer config.yaml (data) over config.py (executable) when both exist.
+
+    Training dumps both formats. Loading config.py via mmengine executes it as
+    Python, which is unsafe for untrusted model directories.
+    """
+    yaml_path = osp(model_dir, "config.yaml")
+    py_path = osp(model_dir, "config.py")
+    if os.path.isfile(yaml_path):
+        return Config.fromfile(yaml_path)
+    if os.path.isfile(py_path):
+        print(
+            "Warning: loading executable config.py because config.yaml is missing. "
+            "Only use model directories you trust."
+        )
+        return Config.fromfile(py_path)
+    raise FileNotFoundError(f"neither config.yaml nor config.py found in {model_dir}")
+
+
 def load_model(model_dir, device):
-    cfg = Config.fromfile(osp(model_dir, "config.py"))
+    cfg = load_config(model_dir)
     model = MIMODEL.build(cfg.model.params.model).to(torch.bfloat16)
     ckpt = torch.load(
         osp(model_dir, "last.ckpt/checkpoint", "mp_rank_00_model_states.pt"),
@@ -47,7 +67,7 @@ def load_stats(cfg, device):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Path to the model dir.")
-    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Bind address. Default is loopback; the socket has no authentication.")
     parser.add_argument("--port", type=int, default=10086)
     return parser.parse_args()
 

--- a/xr1/mibot/server/runtime/client.py
+++ b/xr1/mibot/server/runtime/client.py
@@ -11,6 +11,8 @@ from transformers import AutoProcessor
 
 from mibot.utils.io import compose_state, recover_action, resize_image, split_action
 
+MAX_PAYLOAD_BYTES = 128 * 1024 * 1024
+
 
 class Client:
     def __init__(self, host: str = "localhost", port: int = 10086) -> None:
@@ -43,6 +45,8 @@ class Client:
 
     def _recv(self):
         size = struct.unpack(">I", self._recv_all(self.socket, 4))[0]
+        if size <= 0 or size > MAX_PAYLOAD_BYTES:
+            raise ValueError(f"payload length {size} outside allowed range (1..{MAX_PAYLOAD_BYTES})")
         with np.load(BytesIO(self._recv_all(self.socket, size)), allow_pickle=False) as payload:
             return torch.from_numpy(payload["action"].copy())
 

--- a/xr1/mibot/server/runtime/server.py
+++ b/xr1/mibot/server/runtime/server.py
@@ -12,6 +12,8 @@ from tqdm import tqdm
 
 from mibot.utils.io import ACTION_EPS, denormalize_action
 
+MAX_PAYLOAD_BYTES = 128 * 1024 * 1024
+
 
 class Server:
     def __init__(self, host: str, port: int, model, mean, std, q01, q99, action_mask, device: str) -> None:
@@ -40,6 +42,8 @@ class Server:
         if not head:
             return None
         size = struct.unpack(">I", head)[0]
+        if size <= 0 or size > MAX_PAYLOAD_BYTES:
+            raise ValueError(f"payload length {size} outside allowed range (1..{MAX_PAYLOAD_BYTES})")
         body = self._recv_all(conn, size)
         if body is None:
             return None


### PR DESCRIPTION
## Summary
Hardening for the post-training / mibot inference path (complements [#6](https://github.com/XiaomiRobotics/Xiaomi-Robotics-1/pull/6) on the Hugging Face `deploy/` socket):

1. **Prefer `config.yaml` over `config.py`** when loading a model directory. Training already dumps both (`cfg_utils.process_save_cfg`). `Config.fromfile("config.py")` executes Python; for an untrusted model directory that is code execution at load time. YAML is data.
2. **Default bind `127.0.0.1`** instead of `0.0.0.0` for `mibot/server/deploy.py` (socket has no auth).
3. **128 MiB payload cap** on the mibot runtime length-prefix framing (same class of memory DoS as unbounded `uint32` lengths).

## Non-goals
- Does not remove `torch.load(..., weights_only=False)` yet — DeepSpeed `mp_rank_*` checkpoints may contain non-tensor objects; needs a checked migration.
- Does not add authentication/mTLS on the research eval socket.

## Test plan
- [ ] Deploy a model dir that contains both `config.yaml` and `config.py` — yaml path is used
- [ ] Deploy a dir with only `config.py` — warning printed, still loads
- [ ] Oversized length prefix is rejected without allocating
- [ ] Normal mibot client/server inference still works on loopback

Made with [Cursor](https://cursor.com)