### PR TITLE
fix(mibot): bound action_prefix before packing

### DIFF
--- a/xr1/mibot/server/runtime/client.py
+++ b/xr1/mibot/server/runtime/client.py
@@ -109,6 +109,20 @@ class Client:
         )[None]
         if action_prefix is not None:
             action_prefix = np.asarray(action_prefix, dtype=np.float32)
+            if action_prefix.ndim != 2:
+                raise ValueError(
+                    f"action_prefix must be a 2D array of shape (N, 60), got {action_prefix.shape}"
+                )
+            if action_prefix.shape[1] != 60:
+                raise ValueError(
+                    f"action_prefix columns must be 60, got {action_prefix.shape[1]}"
+                )
+            if len(action_prefix) > 30:
+                raise ValueError(
+                    f"action_prefix length {len(action_prefix)} exceeds action_length 30"
+                )
+            if not np.isfinite(action_prefix).all():
+                raise ValueError("action_prefix must contain only finite values")
             action = np.zeros((30, 60), dtype=np.float32)
             action[: len(action_prefix)] = action_prefix
             payload["action"] = torch.from_numpy(action)[None]


### PR DESCRIPTION
## Summary
`action_prefix` in `xr1/mibot/server/runtime/client.py` is copied into a fixed `(30, 60)` action buffer without checking length or shape. An `(N > 30, 60)` prefix crashes with an unhelpful numpy slice error; wrong column counts fail later in the model path.

Validate:
- 2D shape `(N, 60)`
- `N <= 30` (action horizon)
- finite values

fail fast with clear errors.

## Why this is small and valid
- Confirmed defect: `action[: len(action_prefix)] = action_prefix` raises `ValueError: could not broadcast ...` when `len > 30`, with no hint to the caller.
- Keeps existing behavior for valid prefixes; no protocol change.

Related to the socket hardening in [#6](https://github.com/XiaomiRobotics/Xiaomi-Robotics-1/pull/6) / [#7](https://github.com/XiaomiRobotics/Xiaomi-Robotics-1/pull/7) but independent.

## Test plan
- [ ] Passing `(30, 60)` prefix still works
- [ ] `(31, 60)` raises the new clear error
- [ ] `(5, 59)` raises the new clear error

Made with [Cursor](https://cursor.com)