### PR TITLE
fix(mibot): default deploy bind to localhost

### DIFF
--- a/xr1/mibot/server/deploy.py
+++ b/xr1/mibot/server/deploy.py
@@ -47,7 +47,15 @@ def load_stats(cfg, device):
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Path to the model dir.")
-    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Bind address for the inference socket (no auth; default localhost). "
+            "Use 0.0.0.0 only on a trusted network or behind an auth proxy."
+        ),
+    )
     parser.add_argument("--port", type=int, default=10086)
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
`xr1/mibot/server/deploy.py` defaults `--host` to `0.0.0.0`, exposing an **unauthenticated inference socket** on all interfaces when a user just runs the script (or the packaged `scripts/deploy.sh`). That invites remote model queries / resource exhaustion from the LAN or wider network if the host is reachable.

Default to `127.0.0.1` and document the risk in `--help` for anyone who explicitly needs `0.0.0.0` (trusted network / auth proxy).

Related to [#7](https://github.com/XiaomiRobotics/Xiaomi-Robotics-1/pull/7) (config + payload limits) but independent.

## Test plan
- [ ] Default run binds to `127.0.0.1` only
- [ ] `--host 0.0.0.0` still binds all interfaces, with help text warning

Made with [Cursor](https://cursor.com)