### PR TITLE
fix(trainer): deterministic dataloader workers and generator

### DIFF
--- a/xr1/mibot/data/datamodule/base_datamodule.py
+++ b/xr1/mibot/data/datamodule/base_datamodule.py
@@ -3,6 +3,9 @@ from copy import deepcopy
 
 from lightning import LightningDataModule
 from mmengine import Config, DATASETS
+import os
+
+import torch
 from torch.utils.data import DataLoader, DistributedSampler
 
 from mibot.data.collate.custom_collate import CustomCollate
@@ -25,6 +28,10 @@ class BaseDataModule(LightningDataModule):
     def train_dataloader(self) -> DataLoader:
         if self.train_set is None:
             self.setup("fit")
+        generator = torch.Generator()
+        generator.manual_seed(
+            int(os.environ.get("RANK", 0)) + int(self.params.get("seed", 42))
+        )
         sampler = DistributedSampler(self.train_set, shuffle=True, seed=42)
         return DataLoader(
             self.train_set,
@@ -35,4 +42,18 @@ class BaseDataModule(LightningDataModule):
             collate_fn=self.collate_fn,
             persistent_workers=True,
             pin_memory=True,
+            worker_init_fn=_seed_worker,
+            generator=generator,
         )
+
+
+def _seed_worker(worker_id: int) -> None:
+    """Seed each dataloader worker deterministically for reproducibility."""
+    worker_seed = (torch.initial_seed() + worker_id) % 2**32
+    import random
+
+    random.seed(worker_seed)
+    import numpy as np
+
+    np.random.seed(worker_seed)
+    torch.manual_seed(worker_seed)

--- a/xr1/mibot/data/datamodule/base_datamodule.py
+++ b/xr1/mibot/data/datamodule/base_datamodule.py
@@ -1,11 +1,10 @@
 # Copyright (C) 2026 Xiaomi Corporation.
+import os
 from copy import deepcopy
 
+import torch
 from lightning import LightningDataModule
 from mmengine import Config, DATASETS
-import os
-
-import torch
 from torch.utils.data import DataLoader, DistributedSampler
 
 from mibot.data.collate.custom_collate import CustomCollate

--- a/xr1/mibot/data/datamodule/base_datamodule.py
+++ b/xr1/mibot/data/datamodule/base_datamodule.py
@@ -30,7 +30,7 @@ class BaseDataModule(LightningDataModule):
             self.setup("fit")
         generator = torch.Generator()
         generator.manual_seed(
-            int(os.environ.get("RANK", 0)) + int(self.params.get("seed", 42))
+            int(os.environ.get("RANK", 0)) + int(self.params.trainer.get("seed", 42))
         )
         sampler = DistributedSampler(self.train_set, shuffle=True, seed=42)
         return DataLoader(


### PR DESCRIPTION
## Summary
`BaseDataModule.train_dataloader()` runs with `num_workers=8` but does not seed the DataLoader generator or the per-worker RNGs. This makes training runs non-deterministic across processes even with `seed_everything(...)`.

Add:
- A `torch.Generator` seeded from `RANK + trainer.seed` for the DataLoader.
- A `worker_init_fn` to seed Python `random`, NumPy, and PyTorch in each worker.

This makes runs reproducible without changing the sampler behavior.

## Test plan
- [ ] Two runs with the same config/data produce identical loss curves (or at least identical batch ordering).

Made with [Cursor](https://cursor.com)