### PR TITLE
Derive the first tmux window index instead of assuming 0

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,8 @@ fi
 tmux kill-session -t $SESSION_NAME 2>/dev/null
 # Create new session
 tmux new-session -d -s $SESSION_NAME
+# The first window is not necessarily index 0: tmux honours base-index from the user's config.
+FIRST_WINDOW=$(tmux list-windows -t $SESSION_NAME -F '#{window_index}' | head -n 1)
 
 # Function to set up environment in a pane
 setup_environment() {
@@ -43,7 +45,7 @@ for ((i=0; i<NUM_PORTS; i++)); do
     if [ $i -eq 0 ]; then
         # Use the first window (already created)
         WINDOW_NAME="server-$(printf "%02d" $i)"
-        tmux rename-window -t $SESSION_NAME:0 $WINDOW_NAME
+        tmux rename-window -t $SESSION_NAME:$FIRST_WINDOW $WINDOW_NAME
         setup_environment "$SESSION_NAME:$WINDOW_NAME"
         tmux send-keys -t $SESSION_NAME:$WINDOW_NAME "CUDA_VISIBLE_DEVICES=$GPU_ID python -u deploy/server.py --model '$MODEL_PATH' --port $PORT" Enter
     else

--- a/xr1/scripts/deploy.sh
+++ b/xr1/scripts/deploy.sh
@@ -22,13 +22,15 @@ if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
     exit 1
 fi
 tmux new-session -d -s "$SESSION_NAME"
+# The first window is not necessarily index 0: tmux honours base-index from the user's config.
+FIRST_WINDOW=$(tmux list-windows -t "$SESSION_NAME" -F '#{window_index}' | head -n 1)
 
 for ((i=0; i<NUM_PORTS; i++)); do
     PORT=$((BASE_PORT + i))
     GPU_ID=$((i % NUM_GPUS))
     WINDOW_NAME="server-$(printf "%02d" "$i")"
     if [ "$i" -eq 0 ]; then
-        tmux rename-window -t "$SESSION_NAME:0" "$WINDOW_NAME"
+        tmux rename-window -t "$SESSION_NAME:$FIRST_WINDOW" "$WINDOW_NAME"
     else
         tmux new-window -d -t "$SESSION_NAME" -n "$WINDOW_NAME"
     fi


### PR DESCRIPTION
Thank you for releasing XR-1 together with the full eval stack — being able to run the whole
deployment path end to end is what made this reproducible, and I appreciate the work that went into
publishing it.

I ran into a small portability issue with both `deploy.sh` scripts and thought it might be worth
reporting, with a fix if you find it useful.

### What happens

Both scripts rename the new session's first window as `<session>:0`, but tmux takes the first window
index from `base-index` in the user's `~/.tmux.conf`. With `set -g base-index 1` the first window is
`1`, so the rename for `i=0` fails and the three `send-keys` calls aimed at the never-created
`server-00` window fail with it. Windows for `i >= 1` are unaffected, since they are created with
`tmux new-window -n "$WINDOW_NAME"`.

Measured on `cfcab04`, Linux, tmux 3.7, with `set -g base-index 1`. The model path is a dummy, since
both scripts fail before it is used:

```
$ bash scripts/deploy.sh /fake/model 2 1; echo "exit=$?"
can't find window: 0
can't find window: server-00
can't find window: server-00
can't find window: server-00
Started 2 servers in tmux session 'model_servers'
Ports: 10086, 10087
Distributed across 1 GPUs
exit=0

$ tmux list-windows -t model_servers -F '#{window_index}: #{window_name}'
1: tmux
2: server-01
```

Window `1` is the session's first window — never renamed, never sent a command. I also ran it with
`NUM_PORTS=1`, where no server starts at all and the script still prints `Started 1 servers`. I did
not rerun it at the documented `bash scripts/deploy.sh "$MODEL_PATH" 8 8`, but by the same mechanism
that would bring up ports 10087–10093, leave port 10086 down, and still print `Started 8 servers`.

`scripts/deploy.sh` has no `set -e`, so the success message and exit status do not depend on any of
this. I did not reproduce the client side, but `deploy/client.py:23` calls
`_connect_with_retry(max_retries=None, retry_interval=1)`, and that loop only raises when
`max_retries is not None` — so my guess is the symptom usually looks like a client hanging rather
than failing.

`xr1/scripts/deploy.sh` runs under `set -euo pipefail`, so it stops at `i=0` instead — but it leaves
the half-built session behind, and its own guard then refuses the next run with
`tmux session 'model_servers' already exists`.

### What this PR does

Asks tmux for the first window index rather than assuming `0`. On a server started with a default
configuration `base-index` is `0` and the expression returns `0`, so nothing changes for users who
never set it.

Verified on this machine: with the patch, `bash scripts/deploy.sh /fake/model 2 1` names both windows
`server-00` and `server-01`, and both receive their server command; `xr1/scripts/deploy.sh` likewise
creates `server-00` and sends its command, and exits 0.

To be precise about what that does and does not show: I used a dummy model path, so this verifies the
tmux plumbing only, not that a server comes up. On my machine the `xr1` server process additionally
needs #18 to launch under the right interpreter.

Happy to adjust the approach, split this per script, or close it if you would rather solve it another
way.
