### PR TITLE
Match the test import to the module filename (XR1.py)

### DIFF
--- a/xr1/tests/test_training_logic.py
+++ b/xr1/tests/test_training_logic.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 
 from mibot.data.datasets.json_dataset import JsonDataset
-from mibot.models.VLA.xr1 import xr1
+from mibot.models.VLA.XR1 import xr1
 
 
 def test_flow_loss_with_empty_mask_is_finite():


### PR DESCRIPTION
Thank you for shipping the post-training stack with tests — running them was the first thing I tried
after `pip install -e .`, which is how I noticed this.

### What happens

At `cfcab04`, `xr1/tests/test_training_logic.py:6` imports `from mibot.models.VLA.xr1 import xr1`,
while the module file is `xr1/mibot/models/VLA/XR1.py`. On a case-sensitive filesystem (ext4 here)
collection fails, so none of the three tests run:

```
$ cd xr1 && python -m pytest tests/test_training_logic.py --collect-only -q
==================================== ERRORS ====================================
________________ ERROR collecting tests/test_training_logic.py _________________
ImportError while importing test module '.../xr1/tests/test_training_logic.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
.../importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_training_logic.py:6: in <module>
    from mibot.models.VLA.xr1 import xr1
E   ModuleNotFoundError: No module named 'mibot.models.VLA.xr1'
no tests collected, 1 error in 6.38s
```

Setup: commit `cfcab04`, Linux/ext4, Python 3.10, the environment from `xr1/assets/requirements.txt`,
with `pip install -e .` run in `xr1/`. I assume this went unnoticed because macOS filesystems are
case-insensitive by default, where the same import resolves — I have not checked that myself.

### What this PR does

Matches the import to the filename. `mibot/models/__init__.py:7` already spells it
`from mibot.models.VLA.XR1 import xr1`, and those are the only two references to the module in the
tree, so this is the one remaining lowercase spelling.

With the change, all three tests pass here (`3 passed in 5.83s`).

Happy to close this if you would rather rename the module file instead — that would work equally well,
it just touches more places.
