### PR TITLE
Pin the interpreter deploy.sh launches the server with

### DIFF
--- a/xr1/scripts/deploy.sh
+++ b/xr1/scripts/deploy.sh
@@ -11,6 +11,9 @@ NUM_PORTS=$2
 NUM_GPUS=$3
 BASE_PORT=10086
 SESSION_NAME="model_servers"
+# tmux panes inherit the tmux *server's* environment, not this shell's, so a bare `python3`
+# resolves outside whatever env the caller activated. Pin the launching interpreter by path.
+PYTHON="${PYTHON:-$(command -v python3)}"
 
 if ! [[ "$NUM_PORTS" =~ ^[1-9][0-9]*$ ]] || ! [[ "$NUM_GPUS" =~ ^[1-9][0-9]*$ ]]; then
     echo "number_of_ports and number_of_gpus must be positive integers"
@@ -33,7 +36,7 @@ for ((i=0; i<NUM_PORTS; i++)); do
         tmux new-window -d -t "$SESSION_NAME" -n "$WINDOW_NAME"
     fi
     tmux send-keys -t "$SESSION_NAME:$WINDOW_NAME" \
-        "TOKENIZERS_PARALLELISM=false CUDA_VISIBLE_DEVICES=$GPU_ID python3 mibot/server/deploy.py --model '$MODEL_PATH' --port $PORT" Enter
+        "TOKENIZERS_PARALLELISM=false CUDA_VISIBLE_DEVICES=$GPU_ID '$PYTHON' mibot/server/deploy.py --model '$MODEL_PATH' --port $PORT" Enter
 done
 
 echo "Started $NUM_PORTS server(s) on ports $BASE_PORT-$((BASE_PORT + NUM_PORTS - 1))"


### PR DESCRIPTION
Thanks again for the release. This is a second, unrelated issue I hit in `xr1/scripts/deploy.sh` while
bringing up the post-training server, kept separate from #16 since the cause is different. The two
branches touch different lines and merge cleanly in either order.

### What happens

The script sends a bare `python3` into a fresh tmux pane. Panes inherit the environment of the **tmux
server**, not of the shell that ran the script, so when the tmux server was started before
`conda activate mibot` the server process comes up under the wrong interpreter — while the script
still reports success and exits 0.

Measured on `cfcab04` (with the window-index fix from #16 applied, otherwise the script stops
earlier on this machine), calling the script from an activated `mibot` environment — home directory
shortened in the paths below:

```
CALLER's python3        : /home/user/conda/envs/mibot/bin/python3
CALLER can import torch : 2.8.0+cu128

$ bash scripts/deploy.sh /fake/model 1 1; echo "exit=$?"
Started 1 server(s) on ports 10086-10086
exit=0
```

but inside the pane the script just created:

```
PANE's python3          : /root/conda/bin/python3

TOKENIZERS_PARALLELISM=false CUDA_VISIBLE_DEVICES=0 python3 mibot/server/deploy.py --model ... --port 10086
Traceback (most recent call last):
  File ".../xr1/mibot/server/deploy.py", line 8, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

The root `scripts/deploy.sh` reads as unaffected — it sends `conda activate mibot` into the pane
before the server command.

### What this PR does

Resolves the interpreter in the calling shell and passes it by path, keeping a `PYTHON` override —
the same variable `scripts/launch_robocasa365.sh:9` already accepts, so the convention is not new to
the repo.

With the patch the pane launches
`'/home/user/conda/envs/mibot/bin/python3' mibot/server/deploy.py`, i.e. the interpreter the caller
had activated.

An alternative that would also work, and may fit your intent better: send `conda activate mibot` into
the pane first, mirroring the root script. Glad to switch to that if you prefer the two scripts to
stay symmetrical.
